### PR TITLE
fix(injection): fix SO definition

### DIFF
--- a/inc/badgeinjection.class.php
+++ b/inc/badgeinjection.class.php
@@ -78,7 +78,8 @@ class PluginBadgesBadgeInjection extends PluginBadgesBadge
       //Remove some options because some fields cannot be imported
       $notimportable            = [11, 30, 80];
       $options['ignore_fields'] = $notimportable;
-      $options['displaytype']   = ["dropdown"       => [2, 6, 7],
+      $options['displaytype']   = ["dropdown"       => [2, 7],
+                                        "text"           => [6],
                                         "user"           => [10],
                                         "multiline_text" => [8],
                                         "date"           => [4, 5],


### PR DESCRIPTION
Serial search option is defined as ```dropdown``` instead of ```text```

![image](https://user-images.githubusercontent.com/7335054/154943290-36d3d842-1435-4361-8b0d-e5a4ccafe54d.png)
